### PR TITLE
Upgrade latest librosa, add easy local run via Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Jupyter
+.cache/
+.ipynb_checkpoints/
+.ipython/
+.jupyter/
+.local/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # Tempo Estimation and Beat Tracking - Pipeline
 A comprehensive pipeline for the Tempo Estimation and Beat Tracking MIR problem, implemented in Python on a Jupyter notebook.
 
+# Local Run
+
+Start Jupyter Lab and Server containers:
+```bash
+docker-compose up
+```
+
+Now you can open the notebook with a browser here: http://localhost:8888
+
+An IDE (like [VS Code](https://code.visualstudio.com/docs/datascience/jupyter-notebooks#_connect-to-a-remote-jupyter-server), tested) can also be used with this Jupyter server container URL: `http://localhost:8889?token=a`
+
 ### Read the full version on [Kaggle](https://www.kaggle.com/code/enrcdamn/tempo-estimation-and-beat-tracking-pipeline) :notes:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  jupyter-lab:
+    container_name: jupyter-lab
+    image: jupyter
+    build:
+      context: .
+      dockerfile: jupyter.Dockerfile
+    entrypoint: bash
+    command: -c " jupyter lab --IdentityProvider.token='' "
+    ports:
+      - "8888:8888"
+    volumes:
+      - $PWD:/home/jovyan
+  jupyter-server:
+    container_name: jupyter-server
+    build:
+      context: .
+      dockerfile: jupyter.Dockerfile
+    entrypoint: bash
+    command: -c " jupyter server --IdentityProvider.token='a' --ServerApp.allow_origin='*' --ServerApp.ip='0.0.0.0' --allow_remote_access=true "
+    ports:
+      - "8889:8888"
+    volumes:
+      - $PWD:/home/jovyan

--- a/jupyter.Dockerfile
+++ b/jupyter.Dockerfile
@@ -1,0 +1,2 @@
+FROM jupyter/datascience-notebook:2023-04-17
+RUN pip install librosa==0.10.0.post2


### PR DESCRIPTION
Synced later code from Kaggle and got it working with latest version of librosa lib. Plus added easy local run capability via Docker. Only a few Librosa API methods needed to change (mostly positional => keyword args). @EnrcDamn This is a great walkthrough, thanks for doing it, would love to talk more with you! Here easier [gist view of python source changes](https://gist.github.com/JohnnyMarnell/f77c5595ea6d9406e3de884689978980).